### PR TITLE
ci: fix publish workflow before v0.4.0 release

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -3,30 +3,33 @@ name: EverCharge ts-ocpp
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       - run: npm ci
       - run: npm test
 
   publish-gpr:
     needs: build
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
           registry-url: https://npm.pkg.github.com/
+          scope: '@evercharge'
       - run: npm ci
       - run: npm publish
         env:


### PR DESCRIPTION
## Summary

The v0.3.1 release publish failed back in 2025-04-21 (logs purged, root cause unknown). Most likely cause: Node 16 EOL. Bumping to Node 24 + current action versions before cutting v0.4.0 so the release actually publishes.

## Changes

- Node 16 to 24 in both build and publish-gpr jobs
- `actions/checkout` v4 to v6, `setup-node` v3 to v6
- Added `workflow_dispatch` trigger to allow manual build-job testing without cutting a release
- Added `if github.event_name == release` guard on publish-gpr so manual dispatch only runs the build job
- Added scope `@evercharge` to publish job `setup-node` step

## Test plan

After merge: `gh workflow run release-package.yml` to trigger the build job in isolation. Confirm build succeeds and publish-gpr is skipped.