### PR TITLE
Inject inbound messageId   into payload before event emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,18 @@ Typescript package implementing the JSON version of the Open Charge Point Protoc
 Open Charge Point Protocol (OCPP, <http://www.openchargealliance.org/>) is a communication protocol between multiple charging stations ("charge points") and a single management software ("central system").
 
 ## Installation
+
+```shell
+npm i @evercharge/ocpp-ts
 ```
-npm i ocpp-ts
+
+## Development
+
+To test this library locally, like during development, run `npm link` at the root of this project. Then, run `npm link @evercharge/ocpp-ts` in the directory of the project you want to test.
+
+```shell
+npm link
+npm link @evercharge/ocpp-ts
 ```
 
 ## Usage
@@ -16,7 +26,7 @@ npm i ocpp-ts
 ```ts
 import {
   OcppServer, OcppClientConnection, BootNotificationRequest, BootNotificationResponse,
-} from 'ocpp-ts';
+} from '@evercharge/ocpp-ts';
 
 const centralSystemSimple = new OcppServer();
 centralSystemSimple.listen(9220);
@@ -44,7 +54,7 @@ import {
   BootNotificationRequest,
   BootNotificationResponse,
   OcppClient, OcppError,
-} from 'ocpp-ts';
+} from '@evercharge/ocpp-ts';
 
 const chargingPointSimple = new OcppClient('CP1111');
 chargingPointSimple.on('error', (err: Error) => {

--- a/__tests__/OcppProtocolTest.ts
+++ b/__tests__/OcppProtocolTest.ts
@@ -1,5 +1,7 @@
-import { Protocol } from '../src/impl/Protocol';
+import { EventEmitter } from 'events';
+
 import { OcppServer } from "../src";
+import { Protocol } from '../src/impl/Protocol';
 import { Server } from '../src/impl/Server';
 
 describe('OcppProtocol', () => {
@@ -21,5 +23,32 @@ describe('OcppProtocol', () => {
   it('should return undefined cp id if provided with undefined input', () => {
     const cpId = Server.getCpIdFromUrl(undefined)
     expect(cpId).toBe(undefined);
+  });
+});
+
+describe('Protocol.onCall messageId injection', () => {
+  it('attaches the messageId to the inbound payload before emitting', (done) => {
+    // minimal socket stub to register listeners on
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+    const wireMessageId = 'inbound-test-id-12345';
+
+    // register a listener on Protocol's internal eventEmitter
+    eventEmitter.on('Heartbeat', (payload: any, callback: any) => {
+      try {
+        expect(payload.messageId).toBe(wireMessageId);
+        callback({ currentTime: new Date().toISOString() });
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    // call the private onCall directly with a valid Heartbeat payload
+    (protocol as any).onCall(wireMessageId, 'Heartbeat', {});
   });
 });

--- a/src/impl/Protocol.ts
+++ b/src/impl/Protocol.ts
@@ -129,7 +129,7 @@ export class Protocol {
           // timeout error
           reject(new OcppError(ERROR_INTERNALERROR, 'No response from the handler'));
         }, 10000);
-
+        payload['messageId'] = messageId;
         const hasListener = this.eventEmitter.emit(request, payload, (result: any) => {
           resolve(result);
         });


### PR DESCRIPTION
## Summary

Attaches the on-wire OCPP-J MessageId to inbound CALL payloads as `payload.messageId` before the event is emitted to the application handler. This lets consumers (e.g., evercharge/central-ocpp) log the actual wire-level MessageId for incoming charger requests instead of generating a parallel uuid.

## Commits

1. Jeremy's original commit (`Add messageId to payload and update readme`) — cherry-picked from the closed PR #3. One line added inside `Protocol.onCall` and a README rebranding pass.
2. New regression test — exercises `Protocol.onCall` via a stubbed socket + injected EventEmitter, asserts the listener receives the injected `payload.messageId`.

## Why

Inbound half of CLOUD-4224 in evercharge/central-ocpp. The outbound half (caller-supplied MessageId in `callRequest`) will land as a separate PR on this repo. Together they allow central-ocpp to correlate its `raw_messages` table rows with actual OCPP-J wire frames.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` all passing (10 tests, including the new regression test)