### PR TITLE
fix(protocol): clear callRequest timeout on response

### DIFF
--- a/__tests__/OcppProtocolTest.ts
+++ b/__tests__/OcppProtocolTest.ts
@@ -52,3 +52,58 @@ describe('Protocol.onCall messageId injection', () => {
     (protocol as any).onCall(wireMessageId, 'Heartbeat', {});
   });
 });
+
+describe('Protocol.callRequest timer cleanup', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('clears the timeout when the response arrives', async () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+
+    const promise = protocol.callRequest('Heartbeat', {});
+    expect(jest.getTimerCount()).toBe(1);
+
+    const sentFrame = JSON.parse(fakeSocket.send.mock.calls[0][0]);
+    const messageId = sentFrame[1];
+
+    // Simulate receiving a response from the client
+    (protocol as any).onCallResult(messageId, {currentTime: '2026-01-01T00:00:00Z'});
+
+    await promise;
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('clears the timeout when an error response arrives', async () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+
+    const promise = protocol.callRequest('Heartbeat', {}).catch(() => {
+      // swallow the expected error for test purposes
+    });
+    expect(jest.getTimerCount()).toBe(1);
+
+    const sentFrame = JSON.parse(fakeSocket.send.mock.calls[0][0]);
+    const messageId = sentFrame[1];
+
+    (protocol as any).onCallError(messageId, 'GenericError', 'test error', {});
+
+    await promise;
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/impl/Protocol.ts
+++ b/src/impl/Protocol.ts
@@ -14,7 +14,13 @@ const CALLRESULT_MESSAGE = 3; // Server-to-Client
 const CALLERROR_MESSAGE = 4; // Server-to-Client
 
 export class Protocol {
-  pendingCalls: any = {};
+  pendingCalls: {
+    [messageId: string]: {
+      resolve: (value: any) => void;
+      reject: (reason?: any) => void;
+      timer: NodeJS.Timeout;
+    };
+  } = {};
 
   eventEmitter: EventEmitter;
 
@@ -63,15 +69,15 @@ export class Protocol {
           request,
           payload]);
         this.socket.send(result);
-        this.pendingCalls[messageId] = {
-          resolve,
-          reject,
-        };
-
-        setTimeout(() => {
+        const timer = setTimeout(() => {
           // timeout error
           this.onCallError(messageId, ERROR_INTERNALERROR, 'No response from the client', {});
         }, 10000);
+        this.pendingCalls[messageId] = {
+          resolve,
+          reject,
+          timer,
+        };
       } catch (e) {
         console.error(e);
         reject(e);
@@ -99,7 +105,8 @@ export class Protocol {
     errorDetails: any,
   ) {
     if (this.pendingCalls[messageId]) {
-      const { reject } = this.pendingCalls[messageId];
+      const { reject, timer } = this.pendingCalls[messageId];
+      clearTimeout(timer);
       if (reject) {
         reject(new OcppError(errorCode, errorDescription, errorDetails));
       }
@@ -109,7 +116,8 @@ export class Protocol {
 
   private onCallResult(messageId: string, payload: any) {
     if (this.pendingCalls[messageId]) {
-      const { resolve } = this.pendingCalls[messageId];
+      const { resolve, timer } = this.pendingCalls[messageId];
+      clearTimeout(timer);
       if (resolve) {
         resolve(payload);
       }


### PR DESCRIPTION
## Summary

`Protocol.callRequest` set a 10-second timeout that was never cleared when the response arrived. The timer's closure retained the full serialized request string until it fired, then no-op'd because the `pendingCalls` entry was already deleted.

Now the timer handle is stored on `pendingCalls[messageId]` and cleared by both `onCallResult` and `onCallError`, before `resolve`/`reject` runs. Also tightens the `pendingCalls` field from `any` to a structured type.

## Why

On a heartbeat-heavy workload, every CSMS-to-CP request held ~10s of closure retention and kept a pending timer on the event loop. On graceful shutdown, the process had to wait for all pending timers to drain before exiting cleanly. Both are fixed.

Part of CLOUD-4224.

## Test plan

- [x] Two new tests in `__tests__/OcppProtocolTest.ts` use `jest.useFakeTimers()` and `jest.getTimerCount()` to assert the timer is cleared after both successful and errored responses
- [x] `npm run build` clean
- [x] `npm test` all 12 tests passing