### PR TITLE
feat(protocol): make callRequest timeout configurable

### DIFF
--- a/__tests__/OcppProtocolTest.ts
+++ b/__tests__/OcppProtocolTest.ts
@@ -107,3 +107,57 @@ describe('Protocol.callRequest timer cleanup', () => {
     expect(jest.getTimerCount()).toBe(0);
   });
 });
+
+describe('Protocol.callRequest configurable timeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('rejects after the configured timeout when no response arrives', async () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket, 5000);
+
+    let rejected = false;
+    const promise = protocol.callRequest('Heartbeat', {}).catch((err) => {
+      rejected = true;
+    });
+
+    jest.advanceTimersByTime(4999);
+    await Promise.resolve();
+    expect(rejected).toBe(false);
+
+    jest.advanceTimersByTime(2);
+    await promise;
+    expect(rejected).toBe(true);
+  });
+
+  it('falls back to the 10000ms default when no timeout is configured', async () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+
+    let rejected = false;
+    const promise = protocol.callRequest('Heartbeat', {}).catch((err) => {
+      rejected = true;
+    });
+
+    jest.advanceTimersByTime(9999);
+    await Promise.resolve();
+    expect(rejected).toBe(false);
+
+    jest.advanceTimersByTime(2);
+    await promise;
+    expect(rejected).toBe(true);
+  });
+});

--- a/src/impl/Client.ts
+++ b/src/impl/Client.ts
@@ -9,6 +9,8 @@ export class Client extends EventEmitter {
 
   private cpId: string;
 
+  private callTimeoutMs: number;
+
   private webSocket: WebSocket | undefined;
 
   public close() {
@@ -29,9 +31,10 @@ export class Client extends EventEmitter {
     this.removeAllListeners();
   }
 
-  constructor(cpId: string) {
+  constructor(cpId: string, callTimeoutMs: number = 10000) {
     super();
     this.cpId = cpId;
+    this.callTimeoutMs = callTimeoutMs;
   }
 
   protected getCpId(): string {
@@ -69,7 +72,7 @@ export class Client extends EventEmitter {
 
     ws.on('open', () => {
       if (ws) {
-        this.setConnection(new Protocol(this, ws));
+        this.setConnection(new Protocol(this, ws, this.callTimeoutMs));
         this.emit('connect');
       }
     });

--- a/src/impl/Protocol.ts
+++ b/src/impl/Protocol.ts
@@ -26,9 +26,12 @@ export class Protocol {
 
   socket: WebSocket;
 
-  constructor(eventEmitter: EventEmitter, socket: WebSocket) {
+  private callTimeoutMs: number;
+
+  constructor(eventEmitter: EventEmitter, socket: WebSocket, callTimeoutMs: number = 10000) {
     this.eventEmitter = eventEmitter;
     this.socket = socket;
+    this.callTimeoutMs = callTimeoutMs;
     this.socket.on('message', (message) => {
       this.onMessage(message.toString());
     });
@@ -72,7 +75,7 @@ export class Protocol {
         const timer = setTimeout(() => {
           // timeout error
           this.onCallError(messageId, ERROR_INTERNALERROR, 'No response from the client', {});
-        }, 10000);
+        }, this.callTimeoutMs);
         this.pendingCalls[messageId] = {
           resolve,
           reject,
@@ -136,7 +139,7 @@ export class Protocol {
         setTimeout(() => {
           // timeout error
           reject(new OcppError(ERROR_INTERNALERROR, 'No response from the handler'));
-        }, 10000);
+        }, this.callTimeoutMs);
         payload['messageId'] = messageId;
         const hasListener = this.eventEmitter.emit(request, payload, (result: any) => {
           resolve(result);

--- a/src/impl/Server.ts
+++ b/src/impl/Server.ts
@@ -17,6 +17,13 @@ export class Server extends EventEmitter {
 
   private clients: Array<Client> = [];
 
+  private callTimeoutMs: number;
+
+  constructor(callTimeoutMs: number = 10000) {
+    super();
+    this.callTimeoutMs = callTimeoutMs;
+  }
+
   public close() {
     this.removeAllListeners();
     this.server?.close((err) => {
@@ -92,7 +99,7 @@ export class Server extends EventEmitter {
     }
 
     const client = new OcppClientConnection(cpId);
-    client.setConnection(new Protocol(client, socket));
+    client.setConnection(new Protocol(client, socket, this.callTimeoutMs));
 
     socket.on('error', (err) => {
       console.info(err.message, socket.readyState);


### PR DESCRIPTION
## Summary

Protocol, Client, and Server constructors accept an optional `callTimeoutMs` parameter (default 10000). Previously the 10-second request timeout was hardcoded inside `Protocol.callRequest`.

- `Protocol(eventEmitter, socket, callTimeoutMs?)` — the underlying plumbing
- `Client(cpId, callTimeoutMs?)` — forwards to the Protocol it constructs in `connect()`
- `Server(callTimeoutMs?)` — forwards to the Protocol it constructs per incoming connection

## Why

Preparing for scenarios where central-ocpp may need longer or shorter per-connection timeouts (e.g., slow firmware uploads, aggressive health-check intervals). The default stays at 10s so existing callers are unaffected.

`OcppClient` and `OcppClientConnection` inherit from `Client` but currently do not surface the option in their own constructors. Consumers who need to set it can add the plumbing at that point — intentionally not speculated on here.

Part of CLOUD-4224.

## Test plan

- [x] Two new tests in `__tests__/OcppProtocolTest.ts` assert the configured timeout value fires at the right boundary and that the default still applies when no value is passed
- [x] `npm run build` clean
- [x] `npm test` all tests passing