### PR TITLE
feat(protocol): accept optional caller-supplied messageId in callRequest

### DIFF
--- a/__tests__/OcppProtocolTest.ts
+++ b/__tests__/OcppProtocolTest.ts
@@ -161,3 +161,55 @@ describe('Protocol.callRequest configurable timeout', () => {
     expect(rejected).toBe(true);
   });
 });
+
+describe('Protocol.callRequest caller-supplied messageId', () => {
+  it('uses the supplied messageId verbatim on the wire when provided', () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+    const suppliedId = 'test-message-id-12345';
+
+    protocol.callRequest('Heartbeat', {}, suppliedId).catch(() => {
+      // swallow the expected error for test purposes
+    });
+
+    expect(fakeSocket.send).toHaveBeenCalledTimes(1);
+    const sentFrame = JSON.parse(fakeSocket.send.mock.calls[0][0]);
+    expect(sentFrame[0]).toBe(2); // OCPP CALL message type
+    expect(sentFrame[1]).toBe(suppliedId);
+    expect(sentFrame[2]).toBe('Heartbeat');
+  });
+
+  it('generates a uuid when no messageId is supplied (backwards compatibility)', () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+
+    protocol.callRequest('Heartbeat', {}).catch(() => {});
+
+    const sentFrame = JSON.parse(fakeSocket.send.mock.calls[0][0]);
+    expect(sentFrame[1]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('correlates the response using the supplied messageId', async () => {
+    const eventEmitter = new EventEmitter();
+    const fakeSocket: any = {
+      on: jest.fn(),
+      send: jest.fn(),
+    };
+    const protocol = new Protocol(eventEmitter, fakeSocket);
+    const suppliedId = 'correlation-test-id';
+
+    const promise = protocol.callRequest('Heartbeat', {}, suppliedId);
+
+    (protocol as any).onCallResult(suppliedId, { currentTime: '2026-01-01T00:00:00Z' });
+
+    await expect(promise).resolves.toEqual({ currentTime: '2026-01-01T00:00:00Z' });
+  });
+});

--- a/src/OcppClient.ts
+++ b/src/OcppClient.ts
@@ -94,17 +94,17 @@ export class OcppClient extends Client {
     return super.on(event, listener);
   }
 
-  callRequest(request: 'Authorize', payload: AuthorizeRequest): Promise<AuthorizeResponse>
-  callRequest(request: 'BootNotification', payload: BootNotificationRequest): Promise<BootNotificationResponse>
-  callRequest(request: 'DataTransfer', payload: DataTransferRequest): Promise<DataTransferResponse>
-  callRequest(request: 'DiagnosticsStatusNotification', payload: DiagnosticsStatusNotificationRequest): Promise<DiagnosticsStatusNotificationResponse>
-  callRequest(request: 'FirmwareStatusNotification', payload: FirmwareStatusNotificationRequest): Promise<FirmwareStatusNotificationResponse>
-  callRequest(request: 'Heartbeat', payload: HeartbeatRequest): Promise<HeartbeatResponse>
-  callRequest(request: 'MeterValues', payload: MeterValuesRequest): Promise<MeterValuesResponse>
-  callRequest(request: 'StartTransaction', payload: StartTransactionRequest): Promise<StartTransactionResponse>
-  callRequest(request: 'StatusNotification', payload: StatusNotificationRequest): Promise<StatusNotificationResponse>
-  callRequest(request: 'StopTransaction', payload: StopTransactionRequest): Promise<StopTransactionResponse>
-  callRequest(request: string, payload: any): Promise<any> {
-    return super.callRequest(request, payload);
+  callRequest(request: 'Authorize', payload: AuthorizeRequest, messageId?: string): Promise<AuthorizeResponse>
+  callRequest(request: 'BootNotification', payload: BootNotificationRequest, messageId?: string): Promise<BootNotificationResponse>
+  callRequest(request: 'DataTransfer', payload: DataTransferRequest, messageId?: string): Promise<DataTransferResponse>
+  callRequest(request: 'DiagnosticsStatusNotification', payload: DiagnosticsStatusNotificationRequest, messageId?: string): Promise<DiagnosticsStatusNotificationResponse>
+  callRequest(request: 'FirmwareStatusNotification', payload: FirmwareStatusNotificationRequest, messageId?: string): Promise<FirmwareStatusNotificationResponse>
+  callRequest(request: 'Heartbeat', payload: HeartbeatRequest, messageId?: string): Promise<HeartbeatResponse>
+  callRequest(request: 'MeterValues', payload: MeterValuesRequest, messageId?: string): Promise<MeterValuesResponse>
+  callRequest(request: 'StartTransaction', payload: StartTransactionRequest, messageId?: string): Promise<StartTransactionResponse>
+  callRequest(request: 'StatusNotification', payload: StatusNotificationRequest, messageId?: string): Promise<StatusNotificationResponse>
+  callRequest(request: 'StopTransaction', payload: StopTransactionRequest, messageId?: string): Promise<StopTransactionResponse>
+  callRequest(request: string, payload: any, messageId?: string): Promise<any> {
+    return super.callRequest(request, payload, messageId);
   }
 }

--- a/src/OcppClientConnection.ts
+++ b/src/OcppClientConnection.ts
@@ -84,26 +84,26 @@ export class OcppClientConnection extends Client {
     return super.on(event, listener);
   }
 
-  callRequest(request: 'CancelReservation', payload: CancelReservationRequest): Promise<CancelReservationResponse>
-  callRequest(request: 'ChangeAvailability', payload: ChangeAvailabilityRequest): Promise<ChangeAvailabilityResponse>
-  callRequest(request: 'ChangeConfiguration', payload: ChangeConfigurationRequest): Promise<ChangeConfigurationResponse>
-  callRequest(request: 'ClearCache', payload: ClearCacheRequest): Promise<ClearCacheResponse>
-  callRequest(request: 'ClearChargingProfile', payload: ClearChargingProfileRequest): Promise<ClearChargingProfileResponse>
-  callRequest(request: 'DataTransfer', payload: DataTransferRequest): Promise<DataTransferResponse>
-  callRequest(request: 'GetCompositeSchedule', payload: GetCompositeScheduleRequest): Promise<GetCompositeScheduleResponse>
-  callRequest(request: 'GetConfiguration', payload: GetConfigurationRequest): Promise<GetConfigurationResponse>
-  callRequest(request: 'GetDiagnostics', payload: GetDiagnosticsRequest): Promise<GetDiagnosticsResponse>
-  callRequest(request: 'GetLocalListVersion', payload: GetLocalListVersionRequest): Promise<GetLocalListVersionResponse>
-  callRequest(request: 'RemoteStartTransaction', payload: RemoteStartTransactionRequest): Promise<RemoteStartTransactionResponse>
-  callRequest(request: 'RemoteStopTransaction', payload: RemoteStopTransactionRequest): Promise<RemoteStopTransactionResponse>
-  callRequest(request: 'ReserveNow', payload: ReserveNowRequest): Promise<ReserveNowResponse>
-  callRequest(request: 'Reset', payload: ResetRequest): Promise<ResetResponse>
-  callRequest(request: 'SendLocalList', payload: SendLocalListRequest): Promise<SendLocalListResponse>
-  callRequest(request: 'SetChargingProfile', payload: SetChargingProfileRequest): Promise<SetChargingProfileResponse>
-  callRequest(request: 'TriggerMessage', payload: TriggerMessageRequest): Promise<TriggerMessageResponse>
-  callRequest(request: 'UnlockConnector', payload: UnlockConnectorRequest): Promise<UnlockConnectorResponse>
-  callRequest(request: 'UpdateFirmware', payload: UpdateFirmwareRequest): Promise<UpdateFirmwareResponse>
-  callRequest(request: string, payload: any): Promise<any> {
-    return super.callRequest(request, payload);
+  callRequest(request: 'CancelReservation', payload: CancelReservationRequest, messageId?: string): Promise<CancelReservationResponse>;
+  callRequest(request: 'ChangeAvailability', payload: ChangeAvailabilityRequest, messageId?: string): Promise<ChangeAvailabilityResponse>;
+  callRequest(request: 'ChangeConfiguration', payload: ChangeConfigurationRequest, messageId?: string): Promise<ChangeConfigurationResponse>;
+  callRequest(request: 'ClearCache', payload: ClearCacheRequest, messageId?: string): Promise<ClearCacheResponse>;
+  callRequest(request: 'ClearChargingProfile', payload: ClearChargingProfileRequest, messageId?: string): Promise<ClearChargingProfileResponse>;
+  callRequest(request: 'DataTransfer', payload: DataTransferRequest, messageId?: string): Promise<DataTransferResponse>;
+  callRequest(request: 'GetCompositeSchedule', payload: GetCompositeScheduleRequest, messageId?: string): Promise<GetCompositeScheduleResponse>;
+  callRequest(request: 'GetConfiguration', payload: GetConfigurationRequest, messageId?: string): Promise<GetConfigurationResponse>;
+  callRequest(request: 'GetDiagnostics', payload: GetDiagnosticsRequest, messageId?: string): Promise<GetDiagnosticsResponse>;
+  callRequest(request: 'GetLocalListVersion', payload: GetLocalListVersionRequest, messageId?: string): Promise<GetLocalListVersionResponse>;
+  callRequest(request: 'RemoteStartTransaction', payload: RemoteStartTransactionRequest, messageId?: string): Promise<RemoteStartTransactionResponse>;
+  callRequest(request: 'RemoteStopTransaction', payload: RemoteStopTransactionRequest, messageId?: string): Promise<RemoteStopTransactionResponse>;
+  callRequest(request: 'ReserveNow', payload: ReserveNowRequest, messageId?: string): Promise<ReserveNowResponse>;
+  callRequest(request: 'Reset', payload: ResetRequest, messageId?: string): Promise<ResetResponse>;
+  callRequest(request: 'SendLocalList', payload: SendLocalListRequest, messageId?: string): Promise<SendLocalListResponse>;
+  callRequest(request: 'SetChargingProfile', payload: SetChargingProfileRequest, messageId?: string): Promise<SetChargingProfileResponse>;
+  callRequest(request: 'TriggerMessage', payload: TriggerMessageRequest, messageId?: string): Promise<TriggerMessageResponse>;
+  callRequest(request: 'UnlockConnector', payload: UnlockConnectorRequest, messageId?: string): Promise<UnlockConnectorResponse>;
+  callRequest(request: 'UpdateFirmware', payload: UpdateFirmwareRequest, messageId?: string): Promise<UpdateFirmwareResponse>;
+  callRequest(request: string, payload: any, messageId?: string): Promise<any> {
+    return super.callRequest(request, payload, messageId);
   }
 }

--- a/src/impl/Client.ts
+++ b/src/impl/Client.ts
@@ -45,9 +45,9 @@ export class Client extends EventEmitter {
     this.connection = connection;
   }
 
-  protected callRequest(request: string, payload: any): Promise<any> {
+  protected callRequest(request: string, payload: any, messageId?: string): Promise<any> {
     if (this.connection) {
-      return this.connection.callRequest(request, payload);
+      return this.connection.callRequest(request, payload, messageId);
     }
     throw new Error('Charging point not connected to central system');
   }

--- a/src/impl/Protocol.ts
+++ b/src/impl/Protocol.ts
@@ -63,20 +63,20 @@ export class Protocol {
     }
   }
 
-  public callRequest(request: string, payload: any): Promise<any> {
+  public callRequest(request: string, payload: any, messageId?: string): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        const messageId = uuidv4();
+        const id = messageId ?? uuidv4();
         const result = JSON.stringify([CALL_MESSAGE,
-          messageId,
+          id,
           request,
           payload]);
         this.socket.send(result);
         const timer = setTimeout(() => {
           // timeout error
-          this.onCallError(messageId, ERROR_INTERNALERROR, 'No response from the client', {});
+          this.onCallError(id, ERROR_INTERNALERROR, 'No response from the client', {});
         }, this.callTimeoutMs);
-        this.pendingCalls[messageId] = {
+        this.pendingCalls[id] = {
           resolve,
           reject,
           timer,


### PR DESCRIPTION
## Summary

Adds an optional `messageId?: string` parameter to `callRequest` at all four layers: `Protocol`, `Client`, `OcppClient`, and `OcppClientConnection`. When supplied, the value is used verbatim as the OCPP-J wire MessageId. When omitted, behavior is unchanged (uuidv4 generated internally).

## Why

This is the outbound complement to the inbound `payload.messageId` injection landed in #6. Together they let consumers correlate request/response pairs in their own logs using the actual on-wire MessageId rather than a parallel uuid.

`evercharge/central-ocpp` specifically needs this so its `OCPPRequester.send` can thread a single uuid through both the `raw_messages` log row and the wire frame. Today they are independent uuids — the logged id never touches the wire, so DB rows can't be correlated with anything a charger echoes back.

The OCPP-J spec mandates that responders echo the request MessageId verbatim, so a single uuid generated at the caller correctly correlates the request, the response, and the DB row.

## Scope

- `Protocol.callRequest(request, payload, messageId?)` — the wire-level implementation. Uses the supplied value or falls back to uuidv4.
- `Client.callRequest(request, payload, messageId?)` — mid-layer dispatcher that forwards to Protocol.
- `OcppClient.callRequest(...)` — 10 overload signatures (CP→CSMS direction: Authorize, BootNotification, Heartbeat, etc.) + dispatcher. 
- `OcppClientConnection.callRequest(...)` — 19 overload signatures (CSMS→CP direction: RemoteStartTransaction, Reset, ChangeConfiguration, etc.) + dispatcher. **This is the one central-ocpp actually uses.**

## Test plan

- [x] Three new tests in `__tests__/OcppProtocolTest.ts`:
  - Supplied messageId appears verbatim on the wire
  - Default uuid still generated when no messageId passed (back-compat)
  - Response correlation works with caller-supplied IDs
- [x] `npm run build` clean (validates all 30+ overload signatures are consistent across four layers)
- [x] `npm test` all passing

Closes the CLOUD-4224 outbound-direction gap in central-ocpp.