### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evercharge/ocpp-ts",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "OCPP 1.6: Open Charge Point Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps package version to 0.4.0 to release the CLOUD-4224 work landed on main since 0.3.2.

## Changes included in this release

- **#5** — terminate() and websocket internals exposure (graceful shutdown hooks)
- **#6** — Inbound payload.messageId injection (handlers can now read the on-wire MessageId from incoming CALL payloads)
- **#7** — setTimeout leak fix in Protocol.callRequest
- **#8** — Configurable callRequest timeout via constructor (default 10000 unchanged)
- **#9** — Optional caller-supplied messageId in callRequest (outbound complement to #6)

## Compatibility

All changes are additive and back-compatible. Existing callers of `@evercharge/ocpp-ts@0.3.2` keep working unchanged.

## Post-merge

Cutting a GitHub Release at tag v0.4.0 will trigger the publish workflow and push to GitHub Packages.