### PR TITLE
Celsius is misspelled in OCPP schema, supporting both

### DIFF
--- a/src/ocpp-1.6-schemas/MeterValues.json
+++ b/src/ocpp-1.6-schemas/MeterValues.json
@@ -114,7 +114,7 @@
 										"A",
 										"V",
 										"K",
-										"Celcius",
+										"Celsius",
 										"Fahrenheit",
 										"Percent"
 									]
@@ -129,7 +129,7 @@
                 "required": [
                     "timestamp",
 					"sampledValue"
-                ]		
+                ]
 			}
 		}
     },

--- a/src/ocpp-1.6-schemas/StopTransaction.json
+++ b/src/ocpp-1.6-schemas/StopTransaction.json
@@ -138,7 +138,7 @@
 										"A",
 										"V",
 										"K",
-										"Celcius",
+										"Celsius",
 										"Fahrenheit",
 										"Percent"
 									]

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,7 +249,7 @@ export interface MeterValuesRequest {
         | "A"
         | "V"
         | "K"
-        | "Celcius"
+        | "Celsius"
         | "Fahrenheit"
         | "Percent";
       [k: string]: unknown;
@@ -516,6 +516,7 @@ export interface StopTransactionRequest {
         | "V"
         | "K"
         | "Celcius"
+        | "Celsius"
         | "Fahrenheit"
         | "Percent";
       [k: string]: unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,7 @@ export interface MeterValuesRequest {
         | "A"
         | "V"
         | "K"
+        | "Celcius"
         | "Celsius"
         | "Fahrenheit"
         | "Percent";


### PR DESCRIPTION
Supporting both `Celcius` and `Celsius`