### PR TITLE
fix(release): make npm publish reproducible and target npmjs.org

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -16,21 +16,20 @@ jobs:
       - run: npm ci
       - run: npm test
 
-  publish-gpr:
+  publish-npm:
     needs: build
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
+      id-token: write          # OIDC for provenance attestation
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://npm.pkg.github.com/
-          scope: '@evercharge'
+          registry-url: https://registry.npmjs.org
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evercharge/ocpp-ts",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evercharge/ocpp-ts",
-      "version": "0.3.2",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@evercharge/ocpp-ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OCPP 1.6: Open Charge Point Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "compileSchema": "npx ts-node scripts/compileSchemas.ts",
     "lint": "eslint ./src",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "rm -rf ./dist/ && tsc",
     "test": "jest"
   },


### PR DESCRIPTION
## Problem

`npm publish` from a clean checkout or CI ships a **broken tarball with no `dist/`**, even though `main`/`types` point at `dist/src/index.js` / `dist/src/index.d.ts`. Root causes:

- The build was wired to the deprecated **`prepublish`** script, which npm 7+ does **not** run on `npm publish`.
- `dist/` is gitignored, so a fresh checkout / CI runner has no build output on disk.
- The release workflow published to **GitHub Packages** (`npm.pkg.github.com` + `GITHUB_TOKEN`), not npmjs.org — leftover after the intent moved to npm in #11.

`0.4.0` only worked because it was hand-published from a working tree that already had `dist/` built and `.npmignore` removed locally — a one-off that the committed config never reproduced.

## Changes

**`package.json`**
- `prepublish` → **`prepare`** so `dist/` is always built on `npm publish` *and* `npm ci`/install
- add **`files: ["dist"]`** allowlist (ships only built output; no stray `src/*.ts`)
- bump to **0.4.1** (also resyncs `package-lock.json`, which had drifted to `0.3.2`)

**`.github/workflows/release-package.yml`**
- publish to **`registry.npmjs.org`** via **`NPM_TOKEN`** secret
- enable **npm provenance** (`--provenance` + `id-token: write`)
- drop stale GitHub Packages config (`packages: write`, `npm.pkg.github.com`, `GITHUB_TOKEN`)

## Verification

`npm publish --dry-run` after deleting `dist/`:
- `prepare` hook rebuilds `dist/` from scratch
- **86** `dist/` files in tarball; `dist/src/index.js` + `dist/src/index.d.ts` present; **0** stray `src/*.ts`

## Release (post-merge)

`NPM_TOKEN` repo secret is already configured. After merge:

```
gh release create v0.4.1 --generate-notes
```

fires `build` → `publish-npm`, publishing `0.4.1` to npmjs.org with provenance.