### PR TITLE
ci(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -22,14 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write          # OIDC for provenance attestation
+      id-token: write          # OIDC identity for trusted publishing + provenance
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+      - run: npm install -g npm@latest   # trusted publishing requires npm >= 11.5.1
       - run: npm ci
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The `v0.4.1` release publish failed with `npm error code EOTP` — the account enforces 2FA on writes, and granular access tokens require an explicit **Bypass 2FA** flag (false by default) that the `NPM_TOKEN` secret didn't have.

Rather than keep a long-lived secret at all, this switches to **OIDC trusted publishing** — CI authenticates via the GitHub `id-token` we already grant, so there's no npm credential stored anywhere.

## Changes (`.github/workflows/release-package.yml`)
- remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step
- add `npm install -g npm@latest` (trusted publishing requires npm ≥ 11.5.1)
- keep `id-token: write`, `registry-url`, and `--provenance` (provenance is automatic under trusted publishing)

## Required npm-side config (one-time, manual)
On npmjs.com → `@evercharge/ocpp-ts` → Settings → **Trusted Publishers** → add GitHub Actions:
- Organization: `evercharge`
- Repository: `ocpp-ts`
- Workflow: `release-package.yml`
- Allowed action: `npm publish`

Once merged and the trusted publisher is configured, re-tagging `v0.4.1` onto this commit triggers a token-free publish with provenance. The `NPM_TOKEN` secret can then be deleted.