### PR TITLE
fix(release): add repository field for provenance validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/evercharge/ocpp-ts/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/evercharge/ocpp-ts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/evercharge/ocpp-ts/issues"
+  },
   "dependencies": {
     "ajv": "^6.12.6",
     "directory-tree": "^3.0.1",


### PR DESCRIPTION
## Why

With OIDC trusted publishing now working, `npm publish --provenance` reached the registry and failed provenance verification:

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/evercharge/ocpp-ts" from provenance
```

npm provenance cross-checks `package.json` `repository.url` against the repo the build ran in. The field was missing entirely (normalizes to `""`), so verification rejected the upload.

## Change

Add to `package.json`:
- `repository` → `git+https://github.com/evercharge/ocpp-ts.git` (normalizes to the URL provenance expects)
- `bugs` → issues URL (conventional companion metadata)

After merge, re-tagging `v0.4.1` triggers the publish, which should now pass provenance verification and land on npm.